### PR TITLE
Updated for the change to registerRouteHandler in miragejs

### DIFF
--- a/lib/msw-config.js
+++ b/lib/msw-config.js
@@ -1,5 +1,59 @@
 import { rest, setupWorker } from 'msw';
 
+const defaultRouteOptions = {
+  coalesce: false,
+  timing: undefined,
+};
+
+/**
+ * Determine if the object contains a valid option.
+ *
+ * @method isOption
+ * @param {Object} option An object with one option value pair.
+ * @return {Boolean} True if option is a valid option, false otherwise.
+ * @private
+ */
+function isOption(option) {
+  if (!option || typeof option !== "object") {
+    return false;
+  }
+
+  let allOptions = Object.keys(defaultRouteOptions);
+  let optionKeys = Object.keys(option);
+  for (let i = 0; i < optionKeys.length; i++) {
+    let key = optionKeys[i];
+    if (allOptions.indexOf(key) > -1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Extract arguments for a route.
+ *
+ * @method extractRouteArguments
+ * @param {Array} args Of the form [options], [object, code], [function, code]
+ * [shorthand, options], [shorthand, code, options]
+ * @return {Array} [handler (i.e. the function, object or shorthand), code,
+ * options].
+ */
+function extractRouteArguments(args) {
+  let [lastArg] = args.splice(-1);
+  if (isOption(lastArg)) {
+    lastArg = assign({}, defaultRouteOptions, lastArg);
+  } else {
+    args.push(lastArg);
+    lastArg = defaultRouteOptions;
+  }
+  let t = 2 - args.length;
+  while (t-- > 0) {
+    args.push(undefined);
+  }
+  args.push(lastArg);
+  return args;
+}
+
 export default class MswConfig {
   urlPrefix;
 
@@ -31,7 +85,8 @@ export default class MswConfig {
       ['options'],
     ].forEach(([verb, alias]) => {
       this[verb] = (path, ...args) => {
-        let handler = mirageServer.registerRouteHandler(verb, path, args);
+        let [rawHandler, customizedCode, options] = extractRouteArguments(args);
+        let handler = mirageServer.registerRouteHandler(verb, path, rawHandler, customizedCode, options);
         let fullPath = this._getFullPath(path);
         let mswHandler = rest[verb](fullPath, async (req, res, ctx) => {
           let queryParams = {};


### PR DESCRIPTION
Updated the contract when creating the handlers to work with MirageJS 0.1.46

Note this version works with MirageJS 0.1.46+