### PR TITLE
Pass MockedRequest with additional getters to mirage handler

### DIFF
--- a/lib/msw-config.js
+++ b/lib/msw-config.js
@@ -98,14 +98,14 @@ export default class MswConfig {
             queryParams[key] = value;
           });
           let request = Object.assign(
+              req,
               {
                 requestBody:
                     typeof req.body === 'string'
                         ? req.body
                         : JSON.stringify(req.body),
                 queryParams: queryParams,
-              },
-              req
+              }
           );
           let [code, headers, response] = await handler(request);
           if (code === 204) {


### PR DESCRIPTION
In my case I want to use the getter `body` with parsed form-data

* https://github.com/mswjs/msw/blob/main/src/utils/request/MockedRequest.ts 
* https://github.com/mswjs/msw/blob/156e80bd39dde08fcf0cb9e7c93221798fe8e3c9/src/utils/request/parseBody.ts#L20