### PR TITLE
Add passthrough support

### DIFF
--- a/lib/msw-config.ts
+++ b/lib/msw-config.ts
@@ -467,7 +467,13 @@ export default class MswConfig {
           }
           // @ts-expect-error this seems to be an issue in msw types
           req.passthrough();
-        } else if (this.mirageServer?.shouldLog()) {
+        }
+
+        // Log a warning for any requests for resources that aren't static assets of the page itself
+        else if (
+          req.url.host !== window.location.host &&
+          this.mirageServer?.shouldLog()
+        ) {
           let namespaceError = '';
           if (this.namespace === '') {
             namespaceError = 'There is no existing namespace defined.';

--- a/lib/msw-config.ts
+++ b/lib/msw-config.ts
@@ -428,11 +428,11 @@ export default class MswConfig {
       paths = ['/**', '/'];
     } else if (Array.isArray(lastArg)) {
       verbs = lastArg;
-      // Need to loop because TS doesn't know if they're strings or arrays
-      for (const arg of args) {
-        if (typeof arg === 'string') {
-          paths.push(arg);
-        }
+    }
+    // Need to loop because TS doesn't know if they're strings or arrays
+    for (const arg of args) {
+      if (typeof arg === 'string') {
+        paths.push(arg);
       }
     }
 

--- a/lib/passthrough-registry.ts
+++ b/lib/passthrough-registry.ts
@@ -1,0 +1,84 @@
+import RouteRecognizer from 'route-recognizer';
+import type { HTTPVerb } from 'miragejs/server';
+
+const noOpHandler = () => {};
+const allVerbs = ['GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'];
+
+/**
+ * Registry
+ *
+ * A registry is a map of HTTP verbs to route recognizers.
+ */
+const createPassthroughRegistry = (path: string, verbs: HTTPVerb[]) => {
+  const registry = new Map();
+
+  const uppercaseUserVerbs = verbs.map((v) => v.toUpperCase());
+
+  const matchingVerbs = allVerbs.filter((v) => {
+    // If the user didn't specify verbs, then use everything
+    if (!verbs || !Array.isArray(verbs) || verbs.length === 0) return true;
+
+    return uppercaseUserVerbs.includes(v);
+  });
+
+  matchingVerbs.forEach((mv) => {
+    const recognizer = new RouteRecognizer();
+    recognizer.add([{ path, handler: noOpHandler }]);
+    registry.set(mv, recognizer);
+  });
+
+  return registry;
+};
+
+/**
+ * Hosts
+ *
+ * a map of hosts to Registries, ultimately allowing
+ * a per-host-and-port, per HTTP verb lookup of RouteRecognizers
+ */
+export default class PassthroughRegistry {
+  registries: Map<string, Map<string, RouteRecognizer>>;
+
+  constructor() {
+    this.registries = new Map();
+    return this;
+  }
+
+  /**
+   * Hosts#forURL - retrieve a map of HTTP verbs to RouteRecognizers
+   *                for a given URL
+   *
+   * @param  {String} url a URL
+   * @param  {String[]} verbs a list of HTTP verbs to passthrough.  Defaults to all verbs if not specified.
+   * @return {Registry}   a map of HTTP verbs to RouteRecognizers
+   *                      corresponding to the provided URL's
+   *                      hostname and port
+   */
+  add(url: string, verbs: HTTPVerb[]) {
+    const { host, pathname } = new URL(url);
+    const registry = this.registries.get(host);
+
+    if (registry === undefined) {
+      this.registries.set(host, createPassthroughRegistry(pathname, verbs));
+    } else {
+      const verbsToSet =
+        Array.isArray(verbs) && verbs.length
+          ? verbs.map((v) => v.toUpperCase())
+          : allVerbs;
+      verbsToSet.forEach((v) => {
+        const existingRecognizer = registry.get(v);
+        if (existingRecognizer) {
+          existingRecognizer.add([{ path: pathname, handler: noOpHandler }]);
+        } else {
+          const recognizer = new RouteRecognizer();
+          recognizer.add([{ path: pathname, handler: noOpHandler }]);
+          registry.set(v, recognizer);
+        }
+      });
+    }
+  }
+
+  retrieve(url: string) {
+    return this.registries.get(url);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
+  "dependencies": {
+    "route-recognizer": "^0.3.4"
+  },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.2",
     "miragejs": "^0.1.47",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+dependencies:
+  route-recognizer:
+    specifier: ^0.3.4
+    version: 0.3.4
+
 devDependencies:
   '@tsconfig/recommended':
     specifier: ^1.0.2
@@ -1245,7 +1250,6 @@ packages:
 
   /route-recognizer@0.3.4:
     resolution: {integrity: sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==}
-    dev: true
 
   /run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}


### PR DESCRIPTION
This adds support for adding passthroughs to msw from a mirage config.

It's handled a bit similarly to pretender, which uses route-recognizer.  This also does, but it builds up a `Map` of hosts to a `Map` of verbs to route recognizers.  I'm using this in my own app with a pnpm patch, and it seems to work correctly, though it's a bit noisy because MSW tries to handle all requests, even for favicons and other resources on the local host.

There are two main improvements to make still:

- [x] Support callback passthroughs. 
- [X] Don't `warn` on unhandled requests to the local dev server.

Not sure if either should be considered blocking on this PR, or we can open an issue to tackle them later since this is at least an improvement.