### PR TITLE
Build for browser, don't bundle msw

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "testing"
   ],
   "scripts": {
-    "build": "tsup lib/msw-config.ts --dts --format esm,cjs",
+    "build": "tsup lib/msw-config.ts --dts --format=cjs,esm --platform=browser --external=msw",
     "test": "yarn",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "mirage-msw",
   "version": "0.1.1",
   "description": "Allow mirage to use MSW (Mock Service Worker) as the interceptor",
-  "main": "index.js",
+  "main": "dist/msw-config.cjs",
+  "module": "dist/msw-config.js",
   "type": "module",
   "keywords": [
     "msw",


### PR DESCRIPTION
This solves some problems I was seeing when trying to use the build output in my app.  By default, tsup bundles all dependencies in `devDependencies` if they are imported by your code.  I thought that it would ignore any specified in `peerDependencies`, but that doesn't seem to be the case (I opened https://github.com/egoist/tsup/issues/998 to clarify).

So, this explicitly adds `msw` to externals, to make sure it's not bundled (we want to use the one installed by the user).

I also added the `--platform=browser` flag, since we're building for browsers and not node.

This also fixes the `main` in package.json, and adds a `module` property for legacy tools that don't understand `exports` maps.